### PR TITLE
Add `load_sheet()` helper for unified xls/xlsx support

### DIFF
--- a/bank_reconciliation/parsers.py
+++ b/bank_reconciliation/parsers.py
@@ -1,7 +1,7 @@
 import openpyxl
 from pathlib import Path
 import pandas as pd
-
+from utils import load_sheet
 
 class BankParserBase:
     def __init__(self, path):        # path = pathlib.Path
@@ -19,8 +19,9 @@ class CitiParser(BankParserBase):    # your existing logic
     HEADER_KEYWORD = "細節描述"
 
     def extract_rows(self):
-        wb = openpyxl.load_workbook(self.path, data_only=True)
-        ws = wb[self.SHEET_NAME]
+        # wb = openpyxl.load_workbook(self.path, data_only=True)
+        # ws = wb[self.SHEET_NAME]
+        ws = load_sheet(self.path, sheet=self.SHEET_NAME)
 
         # 1) find header row(s)
         hits = [
@@ -55,13 +56,14 @@ class CTBCParser(BankParserBase):
 
     def extract_rows(self):
         # 1) read entire sheet into a DataFrame (no header row)
-        df = pd.read_excel(
-            self.path,
-            sheet_name=0,
-            header=None,
-            engine="xlrd",
-            dtype=str   # read everything as strings to preserve formatting
-        )
+        # df = pd.read_excel(
+        #     self.path,
+        #     sheet_name=0,
+        #     header=None,
+        #     engine="xlrd",
+        #     dtype=str   # read everything as strings to preserve formatting
+        # )
+        df = load_sheet(self.path, sheet=0, header=None)
 
         # 2) locate your header row by scanning column J
         #    column J → DataFrame column index 9 (0-based)

--- a/bank_reconciliation/utils.py
+++ b/bank_reconciliation/utils.py
@@ -1,0 +1,41 @@
+import openpyxl
+import pandas as pd
+from pathlib import Path
+from typing import Union
+
+def load_sheet(path: Union[str, Path],
+               sheet: Union[int, str] = 0,
+               header: Union[int, None] = None) -> Union[openpyxl.worksheet.worksheet.Worksheet, pd.DataFrame]:
+    """
+    Load a sheet from .xlsx (via openpyxl) or .xls (via pandas/xlrd).
+    
+    - path: path to your bank file
+    - sheet: sheet name or index (0-based for pandas, name or index for openpyxl)
+    - header: only for pandas read_excel; which row to treat as header (None = all rows are data)
+    
+    Returns:
+      - openpyxl Worksheet (if .xlsx)
+      - pd.DataFrame (if .xls)
+    """
+    p = Path(path)
+    ext = p.suffix.lower()
+    
+    if ext == ".xlsx":
+        wb = openpyxl.load_workbook(p, data_only=True)
+        # if they passed an integer, pick by index; otherwise by name
+        if isinstance(sheet, int):
+            return wb.worksheets[sheet]
+        else:
+            return wb[sheet]
+    
+    elif ext == ".xls":
+        # pandas with xlrd
+        return pd.read_excel(
+            p,
+            sheet_name=sheet,
+            header=header,
+            engine="xlrd",
+            dtype=str  # read everything as string so you can strip/convert
+        )
+    else:
+        raise ValueError(f"Unsupported extension {ext!r}, expected .xls or .xlsx")


### PR DESCRIPTION


**Description:**

This PR introduces a shared utility function `load_sheet(path)` to handle both `.xls` (via `pandas+xlrd`) and `.xlsx` (via `openpyxl`) bank statement files.

### ✅ Changes

* Added `load_sheet(path)` in `parsers.py`
* Refactored `CitiParser` and `CTBCParser` to use this helper
* Ensures future parsers (e.g. Mega Bank) can rely on consistent sheet loading logic

### 🔍 Why

Several banks export `.xls` while others use `.xlsx`. This helper abstracts format-specific loading so that each parser doesn’t have to handle it separately.
