### PR TITLE
Add Sinopac (永豐) bank parser support

### DIFF
--- a/bank_reconciliation/bank.py
+++ b/bank_reconciliation/bank.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 from pathlib import Path
-from parsers import CitiParser, CTBCParser, MegaParser, FubonParser, BankParserBase
+from parsers import CitiParser, CTBCParser, MegaParser, FubonParser, SinopacParser, BankParserBase
 
 PARSER_REGISTRY = {
     "花旗": CitiParser,
     "中信": CTBCParser,
     "兆豐": MegaParser,
     "富邦": FubonParser,
+    "永豐": SinopacParser,
     # …more banks later…
 }
 
@@ -45,6 +46,7 @@ BANK_MAP = {
     "中信": "中信營業 NTD 0800",
     "兆豐": "兆豐竹科新安 NTD 2656",
     "富邦": "富邦仁愛 NTD 6332",
+    "永豐": "永豐城中 NTD 7978",
 
     # …add more banks here…
 }


### PR DESCRIPTION
**Description:**

This PR adds support for parsing 永豐銀行 (Sinopac) statements in the format:

* File pattern: `1000 - 永豐-*.xlsx` or `.xls`
* Amount column: **F**, labeled `存入`
* Customer name: **J**, under `備註`
* Sheet name: `工作表1`
* Stops parsing when customer (column J) is blank

**Changes:**

* Added `SinopacParser` to `parsers.py`
* Registered parser in `PARSER_REGISTRY` in `bank.py`

**Tested with:**

* `1000 - 永豐 1140715.xlsx`
* ✅ 1 customer row successfully matched and mapped
* ✅ Verified correct output to accounting template

