### PR TITLE
 Add GUI launcher and “Both” mode for filling 2‑2 (MRS0014 + RPTIS10)

### DIFF
--- a/ytm_forms/scripts/Run GUI.bat
+++ b/ytm_forms/scripts/Run GUI.bat
@@ -1,0 +1,5 @@
+@echo off
+set PYTHON=%~dp0..\..\venv\Scripts\python.exe
+if not exist "%PYTHON%" set PYTHON=py
+"%PYTHON%" "%~dp0run_gui.py"
+pause

--- a/ytm_forms/scripts/fill_2_2.py
+++ b/ytm_forms/scripts/fill_2_2.py
@@ -326,7 +326,7 @@ def run_rptis10(template_path: Path, period: str, rpt_path: str | None, out_path
 # ---------- CLI ----------
 def main():
     ap = argparse.ArgumentParser(description="Fill YTM forms")
-    ap.add_argument("--task", required=True, choices=["mrs0014", "rptis10"])
+    ap.add_argument("--task", required=True, choices=["mrs0014", "rptis10", "both"])
     ap.add_argument("--period", required=True, help="e.g., 202504")
     ap.add_argument("--template", required=True, help="Path to the template workbook to fill")
     ap.add_argument("--out", help="Output path (.xlsx). Omit and use --inplace to overwrite template")
@@ -344,7 +344,10 @@ def main():
 
     if args.task == "mrs0014":
         run_mrs0014(template_path, args.period, args.mrs, out_path)
-    else:
+    elif args.task == "rptis10":
+        run_rptis10(template_path, args.period, args.rptis, out_path, src_sheet=args.rpt_source_sheet)
+    else:  # both
+        run_mrs0014(template_path, args.period, args.mrs, out_path)
         run_rptis10(template_path, args.period, args.rptis, out_path, src_sheet=args.rpt_source_sheet)
 
     print(f"Done → {out_path}")

--- a/ytm_forms/scripts/run_gui.py
+++ b/ytm_forms/scripts/run_gui.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from pathlib import Path
+# adjust import if your path differs
+from fill_2_2 import run_mrs0014, run_rptis10
+
+def browse_template():
+    path = filedialog.askopenfilename(
+        title="Choose template workbook",
+        filetypes=[("Excel files", "*.xlsx")]
+    )
+    if path:
+        template_var.set(path)
+
+def run_task():
+    task = task_var.get()
+    period = period_var.get().strip()
+    template = template_var.get().strip()
+
+    if not period or len(period) != 6 or not period.isdigit():
+        messagebox.showerror("Missing/invalid period", "Enter period as YYYYMM (e.g., 202504).")
+        return
+    if not template:
+        messagebox.showerror("Missing template", "Please choose the template workbook (.xlsx).")
+        return
+
+    try:
+        tpl = Path(template)
+        # run in-place on the same template
+        if task == "MRS0014":
+            run_mrs0014(tpl, period, None, tpl)
+        elif task == "RPTIS10":
+            run_rptis10(tpl, period, None, tpl)
+        else:  # Both
+            run_mrs0014(tpl, period, None, tpl)
+            run_rptis10(tpl, period, None, tpl)
+        messagebox.showinfo("Done", f"{task} completed successfully.")
+    except Exception as e:
+        messagebox.showerror("Error", str(e))
+
+root = tk.Tk()
+root.title("Fill 2-2 (Click & Run)")
+root.geometry("480x200")
+
+task_var = tk.StringVar(value="MRS0014")
+period_var = tk.StringVar()
+template_var = tk.StringVar()
+
+tk.Label(root, text="Task:").grid(row=0, column=0, sticky="e", padx=8, pady=8)
+tk.OptionMenu(root, task_var, "MRS0014", "RPTIS10", "Both").grid(row=0, column=1, sticky="w", padx=8)
+
+tk.Label(root, text="Period (YYYYMM):").grid(row=1, column=0, sticky="e", padx=8, pady=8)
+tk.Entry(root, textvariable=period_var, width=20).grid(row=1, column=1, sticky="w", padx=8)
+
+tk.Label(root, text="Template file:").grid(row=2, column=0, sticky="e", padx=8, pady=8)
+tk.Entry(root, textvariable=template_var, width=36).grid(row=2, column=1, sticky="w", padx=8)
+tk.Button(root, text="Browse...", command=browse_template).grid(row=2, column=2, padx=8)
+
+tk.Button(root, text="Run", width=12, command=run_task).grid(row=3, column=1, pady=16)
+
+root.mainloop()


### PR DESCRIPTION

**Summary:**
This PR adds a simple Tkinter GUI for non‑technical users and introduces a `--task both` mode in `fill_2_2.py` to run MRS0014 then RPTIS10 on the same template, in‑place.

**Changes:**

* `ytm_forms/scripts/fill_2_2.py`

  * CLI: extend `--task` choices to `["mrs0014", "rptis10", "both"]`.
  * Branch logic: run MRS0014 then RPTIS10 when `--task both` is selected (reuse existing functions).
* `ytm_forms/scripts/run_gui.py` (new)

  * Tkinter UI with:

    * Task dropdown: `MRS0014`, `RPTIS10`, `Both`
    * Period (YYYYMM) input
    * Template file picker
    * Run button (executes in‑place on selected template)
  * Basic validation and success/error popups.
* `ytm_forms/scripts/Run GUI.bat` (new)

  * Double‑click launcher that prefers repo venv Python, falls back to system Python.

**Files (new):**

```text
ytm_forms/scripts/run_gui.py
ytm_forms/scripts/Run GUI.bat
```

**How to use (GUI):**

1. Double‑click `ytm_forms/scripts/Run GUI.bat`
2. Choose **Task** (MRS0014 / RPTIS10 / Both)
3. Enter **Period** (e.g., `202504`)
4. Click **Browse…** and select the template workbook
5. Click **Run** (ensure the template is not open in Excel)

**How to use (CLI):**

```powershell
# Run both in-place on the same template
python ytm_forms\scripts\fill_2_2.py --task both --period 202504 --template "C:\...\202504YTM WITS-C 上櫃公司與關係人間重要交易資訊.xlsx" --inplace
```

**Test Plan:**

* GUI:

  * Run each task individually and “Both” with a known template; verify cells populated and no exceptions.
  * Try invalid period (e.g., `2025-04`) → validation error.
  * Try missing template → validation error.
* CLI:

  * `--task mrs0014` only → correct cells C18/C19 and formula in C21.
  * `--task rptis10` only → A–C rows 6–11 copied to rows 7–12 with merged-cell handling.
  * `--task both` → the two actions occur sequentially, same result as running each separately.
* Edge:

  * No exact period files present in Downloads → fallback picks latest period.
  * Template open in Excel → save fails; close and re-run.
<img width="1673" height="924" alt="Screenshot 2025-08-11 135430" src="https://github.com/user-attachments/assets/fbd04321-bbcc-41cd-af17-201a41d3918f" />