### PR TITLE
Add per-run versioned output files (`-2`, `-3`…) for daily bank reconciliation

### DIFF
--- a/bank_reconciliation/run_gui.py
+++ b/bank_reconciliation/run_gui.py
@@ -52,6 +52,14 @@ class BankRunnerGUI:
         tk.Button(top, text="Remove selected", command=self.remove_selected).pack(side=tk.LEFT)
         tk.Button(top, text="Clear", command=self.clear_files).pack(side=tk.LEFT, padx=(6, 0))
 
+        # # New checkbox
+        # self.force_new_run_var = tk.BooleanVar(value=False)
+        # tk.Checkbutton(
+        #     top,
+        #     text="Start new run (-2/-3…) for this batch",
+        #     variable=self.force_new_run_var
+        # ).pack(side=tk.LEFT, padx=(20, 0))
+
         # File list
         mid = tk.Frame(master)
         mid.pack(fill=tk.BOTH, expand=True, padx=10)
@@ -197,10 +205,10 @@ class BankRunnerGUI:
         self.master.after(0, lambda: self.set_status("Done"))
         self.master.after(0, lambda: self.append_log("=== Run finished ===\n"))
 
-
     def _run_single(self, bank_py: str, filepath: str, ymd: str):
         self.master.after(0, lambda: self.append_log(f"\n-- Processing: {os.path.basename(filepath)} --\n"))
         cmd = [sys.executable, bank_py, "-f", filepath, "-d", ymd]
+
         try:
             env = dict(os.environ)
             env["PYTHONIOENCODING"] = "utf-8"


### PR DESCRIPTION

**Summary:**
This PR changes the output file behavior so each new run for the same date writes to a **separate versioned file** instead of appending to the existing daily file. This makes it easier to distinguish between runs while still preventing duplicates across the same day.

**Changes:**

* **New helpers** in `bank.py`:

  * `day_output_base()`
  * `enumerate_existing_outputs()`
  * `next_versioned_output_path()`
  * `collect_existing_counts()`

* **write\_output():**

  * Now takes `existing_counts` from all earlier files for the date.
  * Writes only new entries based on aggregated counts.
  * Creates new file from template for each run.

* **main():**

  * Chooses next versioned file path for the day.
  * Collects existing counts from all earlier files.
  * Writes to new file; deletes file if no rows written.

**Testing done:**

* Ran script for the same date with:

  1. Bank E only → `…20250625.xlsx`.
  2. Banks A, B, C, D → `…20250625-2.xlsx` with only new entries.
  3. Another run with no new entries → no file created, log shows “No new entries; not creating a new per-run file.”
* Verified duplicate prevention across all files for the same date.

**Closes:** #30 
