### PR TITLE
 Fix: Ignore generated Excel outputs & keep only master/reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,19 @@ Thumbs.db
 
 # Logs
 log.txt
+
+# Ignore all Excel files by default
+*.xlsx
+*.xlsm
+
+# But keep the master workbook
+!fourth/export-科餘-1000-asset.xlsx
+
+# Keep the reference mapping file
+!fourth/會計科目對照表.xlsx
+
+# Excel temp/lock files (always ignore)
+~$*
+
+# (optional) ignore other archives/outputs
+*.zip


### PR DESCRIPTION


**Summary:**
This PR updates `.gitignore` to properly handle Excel files.

**Changes:**

* Ignore all `*.xlsx` / `*.xlsm` by default.
* Keep only `export-科餘-1000-asset.xlsx` and `會計科目對照表.xlsx`.
* Ignore Excel temp lock files (`~$*`).
* Cleaned previously tracked output files from repo.

**Why:**

* Keeps the repo clean and maintainable.
* Ensures only source-of-truth files are versioned.
* Prevents noise from Excel temp/derived files in Git history.
